### PR TITLE
Add default player engine

### DIFF
--- a/src/engine/player/__tests__/player-engine.test.ts
+++ b/src/engine/player/__tests__/player-engine.test.ts
@@ -1,0 +1,654 @@
+import { describe, it, expect } from "vitest";
+import { createRng } from "../../rng.js";
+import { DEFAULT_PLAYER_ENGINE_CONFIG } from "../constants.js";
+import { mapTendency, mapTendencyWithRisk } from "../tendency-mapper.js";
+import { selectSide } from "../side-selection.js";
+import { computeTargetPosition, computeServeTarget } from "../target-placement.js";
+import { decideShot } from "../shot-decision.js";
+import { decideServe } from "../serve-decision.js";
+import { DefaultPlayerEngine, createDefaultPlayerEngineFactory } from "../index.js";
+import type {
+  Player,
+  StrokeCapabilities,
+  Equipment,
+  StrokeTendencies,
+  ServeTendencies,
+  PlayerAttributes,
+  ArrivalState,
+  ShotContext,
+  ServeContext,
+  MatchState,
+} from "../../types/index.js";
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const cfg = DEFAULT_PLAYER_ENGINE_CONFIG;
+
+function makeRng(seed = 42) {
+  return createRng(seed);
+}
+
+const ATTACKER_ATTRIBUTES: PlayerAttributes = {
+  footwork: 82,
+  reaction: 78,
+  spinRead: 75,
+  deception: 70,
+  stamina: 72,
+  mental: 75,
+  service: 80,
+  adaptability: 65,
+};
+
+const CHOPPER_ATTRIBUTES: PlayerAttributes = {
+  footwork: 90,
+  reaction: 82,
+  spinRead: 85,
+  deception: 80,
+  stamina: 88,
+  mental: 78,
+  service: 72,
+  adaptability: 70,
+};
+
+const ATTACKER_CAPS: StrokeCapabilities = {
+  forehand: { powerCeiling: 90, spinCeiling: 88, accuracy: 78, consistency: 80 },
+  backhand: { powerCeiling: 78, spinCeiling: 80, accuracy: 72, consistency: 75 },
+};
+
+const CHOPPER_CAPS: StrokeCapabilities = {
+  forehand: { powerCeiling: 62, spinCeiling: 78, accuracy: 72, consistency: 75 },
+  backhand: { powerCeiling: 40, spinCeiling: 88, accuracy: 85, consistency: 88 },
+};
+
+const ATTACKER_EQUIP: Equipment = {
+  blade: { speed: 88 },
+  forehandRubber: { type: "inverted", spin: 90, speed: 85, control: 65 },
+  backhandRubber: { type: "inverted", spin: 82, speed: 80, control: 72 },
+};
+
+const CHOPPER_EQUIP: Equipment = {
+  blade: { speed: 55 },
+  forehandRubber: { type: "inverted", spin: 85, speed: 70, control: 80 },
+  backhandRubber: { type: "longPips", spin: 40, speed: 35, control: 90 },
+};
+
+const ATTACKER_STROKE_TENDENCIES: StrokeTendencies = {
+  powerBias: 72,
+  spinIntensity: 75,
+  topspinBias: 82,
+  sidespinUsage: 30,
+  depthBias: 70,
+  netClearance: 30,
+  riskTolerance: 65,
+};
+
+const CHOPPER_STROKE_TENDENCIES: StrokeTendencies = {
+  powerBias: 28,
+  spinIntensity: 80,
+  topspinBias: 20,
+  sidespinUsage: 15,
+  depthBias: 65,
+  netClearance: 72,
+  riskTolerance: 30,
+};
+
+const ATTACKER_SERVE_TENDENCIES: ServeTendencies = {
+  length: 60,
+  speed: 70,
+  spinAmount: 75,
+  spinVariation: 55,
+  backspinBias: 35,
+  sidespinBias: 65,
+  risk: 60,
+};
+
+const CHOPPER_SERVE_TENDENCIES: ServeTendencies = {
+  length: 25,
+  speed: 30,
+  spinAmount: 80,
+  spinVariation: 70,
+  backspinBias: 75,
+  sidespinBias: 45,
+  risk: 30,
+};
+
+function makeAttacker(): Player {
+  return {
+    name: "Zhang Wei",
+    handedness: "right",
+    elo: 2100,
+    attributes: ATTACKER_ATTRIBUTES,
+    equipment: ATTACKER_EQUIP,
+    strokeCapabilities: ATTACKER_CAPS,
+    strokeTendencies: ATTACKER_STROKE_TENDENCIES,
+    serveTendencies: ATTACKER_SERVE_TENDENCIES,
+    badges: [],
+  };
+}
+
+function makeChopper(): Player {
+  return {
+    name: "Kim Soo-jin",
+    handedness: "right",
+    elo: 1950,
+    attributes: CHOPPER_ATTRIBUTES,
+    equipment: CHOPPER_EQUIP,
+    strokeCapabilities: CHOPPER_CAPS,
+    strokeTendencies: CHOPPER_STROKE_TENDENCIES,
+    serveTendencies: CHOPPER_SERVE_TENDENCIES,
+    badges: [],
+  };
+}
+
+function makeNeutralMatchState(): MatchState {
+  return {
+    score: { player1: 3, player2: 2 },
+    gamesScore: { player1: 1, player2: 1 },
+    gameNumber: 3,
+    server: "Zhang Wei",
+    player1Name: "Zhang Wei",
+    player2Name: "Kim Soo-jin",
+    isDeuce: false,
+    isGamePoint: false,
+    isMatchPoint: false,
+  };
+}
+
+function makePressureMatchState(): MatchState {
+  return {
+    score: { player1: 10, player2: 9 },
+    gamesScore: { player1: 2, player2: 3 },
+    gameNumber: 6,
+    server: "Zhang Wei",
+    player1Name: "Zhang Wei",
+    player2Name: "Kim Soo-jin",
+    isDeuce: false,
+    isGamePoint: true,
+    isMatchPoint: true,
+  };
+}
+
+function makeArrival(overrides?: Partial<ArrivalState>): ArrivalState {
+  return {
+    ballPosition: { x: 20, y: -80, z: 20 },
+    ballVelocity: { x: 10, y: -300, z: -50 },
+    ballSpin: { x: 0, y: 20, z: 0 },
+    timeAvailable: 0.35,
+    availableSides: ["forehand", "backhand"],
+    positionalDeficit: 0.3,
+    ...overrides,
+  };
+}
+
+function makeShotContext(overrides?: Partial<ShotContext>): ShotContext {
+  return {
+    arrival: makeArrival(),
+    playerPosition: { x: 0, y: 160 },
+    opponentPosition: { x: 0, y: -160 },
+    player: makeAttacker(),
+    opponent: makeChopper(),
+    matchState: makeNeutralMatchState(),
+    rallyHistory: [],
+    recentPoints: [],
+    ...overrides,
+  };
+}
+
+function makeServeContext(overrides?: Partial<ServeContext>): ServeContext {
+  return {
+    playerPosition: { x: 0, y: 160 },
+    opponentPosition: { x: 0, y: -160 },
+    player: makeAttacker(),
+    opponent: makeChopper(),
+    matchState: makeNeutralMatchState(),
+    recentPoints: [],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tendency mapper tests
+// ---------------------------------------------------------------------------
+
+describe("tendency-mapper", () => {
+  it("maps tendency=0 to values near 0", () => {
+    const rng = makeRng();
+    const values = Array.from({ length: 100 }, () => mapTendency(0, rng, cfg));
+    const avg = values.reduce((a, b) => a + b, 0) / values.length;
+    expect(avg).toBeLessThan(0.15);
+    expect(values.every((v) => v >= 0 && v <= 1)).toBe(true);
+  });
+
+  it("maps tendency=100 to values near 1", () => {
+    const rng = makeRng();
+    const values = Array.from({ length: 100 }, () => mapTendency(100, rng, cfg));
+    const avg = values.reduce((a, b) => a + b, 0) / values.length;
+    expect(avg).toBeGreaterThan(0.85);
+    expect(values.every((v) => v >= 0 && v <= 1)).toBe(true);
+  });
+
+  it("maps tendency=50 to values centered around 0.5", () => {
+    const rng = makeRng();
+    const values = Array.from({ length: 100 }, () => mapTendency(50, rng, cfg));
+    const avg = values.reduce((a, b) => a + b, 0) / values.length;
+    expect(avg).toBeGreaterThan(0.4);
+    expect(avg).toBeLessThan(0.6);
+  });
+
+  it("always clamps output to [0, 1]", () => {
+    const rng = makeRng();
+    // Test extreme values and many samples
+    for (let tendency = 0; tendency <= 100; tendency += 10) {
+      for (let i = 0; i < 50; i++) {
+        const v = mapTendency(tendency, rng, cfg);
+        expect(v).toBeGreaterThanOrEqual(0);
+        expect(v).toBeLessThanOrEqual(1);
+      }
+    }
+  });
+
+  it("is deterministic with the same seed", () => {
+    const rng1 = makeRng(123);
+    const rng2 = makeRng(123);
+    const values1 = Array.from({ length: 20 }, () => mapTendency(65, rng1, cfg));
+    const values2 = Array.from({ length: 20 }, () => mapTendency(65, rng2, cfg));
+    expect(values1).toEqual(values2);
+  });
+
+  it("risk amplifies tendency away from center", () => {
+    const rng1 = makeRng(42);
+    const rng2 = makeRng(42);
+    // High tendency (70) with risk should be pushed higher
+    const noRisk = mapTendencyWithRisk(70, 0, rng1, cfg);
+    const highRisk = mapTendencyWithRisk(70, 1, rng2, cfg);
+    // With same seed, high risk should produce a higher value for above-center tendency
+    // (because the amplification adds (0.7 - 0.5) * 1.0 * 0.3 = +0.06)
+    expect(highRisk).toBeGreaterThan(noRisk);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Side selection tests
+// ---------------------------------------------------------------------------
+
+describe("side-selection", () => {
+  it("returns the only available side", () => {
+    const rng = makeRng();
+    expect(selectSide(["forehand"], ATTACKER_CAPS, rng, cfg)).toBe("forehand");
+    expect(selectSide(["backhand"], ATTACKER_CAPS, rng, cfg)).toBe("backhand");
+  });
+
+  it("prefers stronger side statistically", () => {
+    // Attacker forehand is clearly stronger (90+88+78+80=336 vs 78+80+72+75=305)
+    let forehandCount = 0;
+    for (let seed = 0; seed < 200; seed++) {
+      const rng = makeRng(seed);
+      if (selectSide(["forehand", "backhand"], ATTACKER_CAPS, rng, cfg) === "forehand") {
+        forehandCount++;
+      }
+    }
+    // Should pick forehand more often than backhand
+    expect(forehandCount).toBeGreaterThan(100);
+  });
+
+  it("is deterministic with the same seed", () => {
+    const rng1 = makeRng(77);
+    const rng2 = makeRng(77);
+    expect(selectSide(["forehand", "backhand"], ATTACKER_CAPS, rng1, cfg))
+      .toBe(selectSide(["forehand", "backhand"], ATTACKER_CAPS, rng2, cfg));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Target placement tests
+// ---------------------------------------------------------------------------
+
+describe("target-placement", () => {
+  it("depthBias=0 targets near net", () => {
+    const rng = makeRng();
+    const target = computeTargetPosition(0, 0.5, { x: 0, y: -160 }, 160, rng, cfg);
+    // Player at +Y, targets -Y. Short depth → Y close to 0.
+    expect(target.y).toBeGreaterThan(-60);
+    expect(target.y).toBeLessThanOrEqual(0);
+  });
+
+  it("depthBias=1 targets near end line", () => {
+    const rng = makeRng();
+    const target = computeTargetPosition(1, 0.5, { x: 0, y: -160 }, 160, rng, cfg);
+    // Deep target → Y close to -137
+    expect(target.y).toBeLessThan(-100);
+  });
+
+  it("targets are always within table bounds", () => {
+    for (let seed = 0; seed < 100; seed++) {
+      const rng = makeRng(seed);
+      const target = computeTargetPosition(
+        Math.random(),
+        Math.random(),
+        { x: (Math.random() - 0.5) * 100, y: -160 },
+        160,
+        rng,
+        cfg,
+      );
+      expect(Math.abs(target.x)).toBeLessThanOrEqual(cfg.tableHalfWidth);
+      expect(target.y).toBeGreaterThanOrEqual(-cfg.tableHalfLength);
+      expect(target.y).toBeLessThanOrEqual(0);
+    }
+  });
+
+  it("biases target X away from opponent position", () => {
+    // Opponent is at +X (right side). Expect targets biased toward -X (left side).
+    let leftCount = 0;
+    for (let seed = 0; seed < 200; seed++) {
+      const rng = makeRng(seed);
+      const target = computeTargetPosition(
+        0.5, 0.5, { x: 40, y: -160 }, 160, rng, cfg,
+      );
+      if (target.x < 0) leftCount++;
+    }
+    // Should bias left when opponent is right
+    expect(leftCount).toBeGreaterThan(100);
+  });
+
+  it("serve targets are on receiver half", () => {
+    for (let seed = 0; seed < 50; seed++) {
+      const rng = makeRng(seed);
+      const target = computeServeTarget(0.5, 0.5, rng, cfg);
+      expect(target.y).toBeLessThanOrEqual(0);
+      expect(target.y).toBeGreaterThanOrEqual(-cfg.tableHalfLength);
+    }
+  });
+
+  it("short serve tendency targets near net", () => {
+    const rng = makeRng();
+    const target = computeServeTarget(0, 0.3, rng, cfg);
+    expect(target.y).toBeGreaterThan(-60);
+  });
+
+  it("long serve tendency targets near end line", () => {
+    const rng = makeRng();
+    const target = computeServeTarget(1, 0.3, rng, cfg);
+    expect(target.y).toBeLessThan(-100);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Shot decision integration tests
+// ---------------------------------------------------------------------------
+
+describe("decideShot", () => {
+  it("produces valid output ranges", () => {
+    const rng = makeRng();
+    const ctx = makeShotContext();
+    const shot = decideShot(ctx, rng, cfg);
+
+    expect(shot.power).toBeGreaterThanOrEqual(0);
+    expect(shot.power).toBeLessThanOrEqual(1);
+    expect(shot.spinIntensity).toBeGreaterThanOrEqual(0);
+    expect(shot.spinIntensity).toBeLessThanOrEqual(1);
+    expect(shot.spinDirection.topspin).toBeGreaterThanOrEqual(-1);
+    expect(shot.spinDirection.topspin).toBeLessThanOrEqual(1);
+    expect(shot.spinDirection.sidespin).toBeGreaterThanOrEqual(-1);
+    expect(shot.spinDirection.sidespin).toBeLessThanOrEqual(1);
+    expect(shot.deceptionEffort).toBeGreaterThanOrEqual(0);
+    expect(shot.deceptionEffort).toBeLessThanOrEqual(1);
+    expect(shot.netClearance).toBeGreaterThanOrEqual(cfg.minNetClearance);
+    expect(["forehand", "backhand"]).toContain(shot.side);
+  });
+
+  it("attacker produces higher power than chopper", () => {
+    let attackerPowerSum = 0;
+    let chopperPowerSum = 0;
+    const n = 100;
+
+    for (let seed = 0; seed < n; seed++) {
+      const rng1 = makeRng(seed);
+      const rng2 = makeRng(seed + 10000);
+
+      const attackerCtx = makeShotContext({ player: makeAttacker() });
+      const chopperCtx = makeShotContext({ player: makeChopper() });
+
+      attackerPowerSum += decideShot(attackerCtx, rng1, cfg).power;
+      chopperPowerSum += decideShot(chopperCtx, rng2, cfg).power;
+    }
+
+    expect(attackerPowerSum / n).toBeGreaterThan(chopperPowerSum / n);
+  });
+
+  it("chopper produces more backspin (lower topspin value)", () => {
+    let attackerTopspinSum = 0;
+    let chopperTopspinSum = 0;
+    const n = 100;
+
+    for (let seed = 0; seed < n; seed++) {
+      const rng1 = makeRng(seed);
+      const rng2 = makeRng(seed + 10000);
+
+      const attackerCtx = makeShotContext({ player: makeAttacker() });
+      const chopperCtx = makeShotContext({ player: makeChopper() });
+
+      attackerTopspinSum += decideShot(attackerCtx, rng1, cfg).spinDirection.topspin;
+      chopperTopspinSum += decideShot(chopperCtx, rng2, cfg).spinDirection.topspin;
+    }
+
+    // Attacker topspinBias=82 → positive, Chopper topspinBias=20 → negative
+    expect(attackerTopspinSum / n).toBeGreaterThan(chopperTopspinSum / n);
+  });
+
+  it("chopper has higher net clearance than attacker", () => {
+    let attackerClearanceSum = 0;
+    let chopperClearanceSum = 0;
+    const n = 100;
+
+    for (let seed = 0; seed < n; seed++) {
+      const rng1 = makeRng(seed);
+      const rng2 = makeRng(seed + 10000);
+
+      const attackerCtx = makeShotContext({ player: makeAttacker() });
+      const chopperCtx = makeShotContext({ player: makeChopper() });
+
+      attackerClearanceSum += decideShot(attackerCtx, rng1, cfg).netClearance;
+      chopperClearanceSum += decideShot(chopperCtx, rng2, cfg).netClearance;
+    }
+
+    // Chopper netClearance=72 vs Attacker netClearance=30
+    expect(chopperClearanceSum / n).toBeGreaterThan(attackerClearanceSum / n);
+  });
+
+  it("high positional deficit reduces effective risk (safer shots)", () => {
+    let normalPowerSum = 0;
+    let stretchedPowerSum = 0;
+    const n = 100;
+
+    for (let seed = 0; seed < n; seed++) {
+      const rng1 = makeRng(seed);
+      const rng2 = makeRng(seed);
+
+      const normalCtx = makeShotContext({
+        arrival: makeArrival({ positionalDeficit: 0.2 }),
+      });
+      const stretchedCtx = makeShotContext({
+        arrival: makeArrival({ positionalDeficit: 0.9 }),
+      });
+
+      normalPowerSum += decideShot(normalCtx, rng1, cfg).power;
+      stretchedPowerSum += decideShot(stretchedCtx, rng2, cfg).power;
+    }
+
+    // Stretched player should produce slightly lower power due to reduced risk
+    expect(normalPowerSum / n).toBeGreaterThan(stretchedPowerSum / n);
+  });
+
+  it("pressure affects risk based on mental attribute", () => {
+    // Low mental player under pressure → risk increases → more extreme power
+    const lowMentalPlayer = makeAttacker();
+    lowMentalPlayer.attributes = { ...lowMentalPlayer.attributes, mental: 20 };
+
+    const highMentalPlayer = makeAttacker();
+    highMentalPlayer.attributes = { ...highMentalPlayer.attributes, mental: 90 };
+
+    let lowMentalRiskAvg = 0;
+    let highMentalRiskAvg = 0;
+    const n = 100;
+
+    for (let seed = 0; seed < n; seed++) {
+      const rng1 = makeRng(seed);
+      const rng2 = makeRng(seed);
+
+      const lowCtx = makeShotContext({
+        player: lowMentalPlayer,
+        matchState: makePressureMatchState(),
+      });
+      const highCtx = makeShotContext({
+        player: highMentalPlayer,
+        matchState: makePressureMatchState(),
+      });
+
+      // Power is a proxy for risk level
+      lowMentalRiskAvg += decideShot(lowCtx, rng1, cfg).power;
+      highMentalRiskAvg += decideShot(highCtx, rng2, cfg).power;
+    }
+
+    // Low mental under pressure should produce higher risk (more power)
+    expect(lowMentalRiskAvg / n).toBeGreaterThan(highMentalRiskAvg / n);
+  });
+
+  it("is deterministic with the same seed", () => {
+    const rng1 = makeRng(99);
+    const rng2 = makeRng(99);
+    const ctx = makeShotContext();
+
+    const shot1 = decideShot(ctx, rng1, cfg);
+    const shot2 = decideShot(ctx, rng2, cfg);
+
+    expect(shot1).toEqual(shot2);
+  });
+
+  it("recovery target is behind player end line", () => {
+    const rng = makeRng();
+    const ctx = makeShotContext({ playerPosition: { x: 0, y: 160 } });
+    const shot = decideShot(ctx, rng, cfg);
+    // Player at +Y, recovery should be at +Y (behind their end)
+    expect(shot.recoveryTarget.y).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Serve decision tests
+// ---------------------------------------------------------------------------
+
+describe("decideServe", () => {
+  it("produces valid output ranges", () => {
+    const rng = makeRng();
+    const ctx = makeServeContext();
+    const serve = decideServe(ctx, rng, cfg);
+
+    expect(serve.power).toBeGreaterThanOrEqual(0);
+    expect(serve.power).toBeLessThanOrEqual(1);
+    expect(serve.spinIntensity).toBeGreaterThanOrEqual(0);
+    expect(serve.spinIntensity).toBeLessThanOrEqual(1);
+    expect(serve.spinDirection.topspin).toBeGreaterThanOrEqual(-1);
+    expect(serve.spinDirection.topspin).toBeLessThanOrEqual(1);
+    expect(serve.spinDirection.sidespin).toBeGreaterThanOrEqual(-1);
+    expect(serve.spinDirection.sidespin).toBeLessThanOrEqual(1);
+    expect(serve.deceptionEffort).toBeGreaterThanOrEqual(0);
+    expect(serve.deceptionEffort).toBeLessThanOrEqual(1);
+    expect(serve.netClearance).toBeGreaterThanOrEqual(cfg.minNetClearance);
+    expect(["forehand", "backhand"]).toContain(serve.side);
+  });
+
+  it("chopper serve has backspin bias (negative topspin)", () => {
+    let topspinSum = 0;
+    const n = 100;
+
+    for (let seed = 0; seed < n; seed++) {
+      const rng = makeRng(seed);
+      const ctx = makeServeContext({ player: makeChopper() });
+      topspinSum += decideServe(ctx, rng, cfg).spinDirection.topspin;
+    }
+
+    // Chopper backspinBias=75 → topspin axis should average negative
+    expect(topspinSum / n).toBeLessThan(0);
+  });
+
+  it("attacker serve has topspin/flat bias", () => {
+    let topspinSum = 0;
+    const n = 100;
+
+    for (let seed = 0; seed < n; seed++) {
+      const rng = makeRng(seed);
+      const ctx = makeServeContext({ player: makeAttacker() });
+      topspinSum += decideServe(ctx, rng, cfg).spinDirection.topspin;
+    }
+
+    // Attacker backspinBias=35 → (50-35)/50 = +0.3 → average positive
+    expect(topspinSum / n).toBeGreaterThan(0);
+  });
+
+  it("is deterministic with the same seed", () => {
+    const rng1 = makeRng(55);
+    const rng2 = makeRng(55);
+    const ctx = makeServeContext();
+
+    const serve1 = decideServe(ctx, rng1, cfg);
+    const serve2 = decideServe(ctx, rng2, cfg);
+
+    expect(serve1).toEqual(serve2);
+  });
+
+  it("targets are on receiver half (negative Y)", () => {
+    for (let seed = 0; seed < 50; seed++) {
+      const rng = makeRng(seed);
+      const ctx = makeServeContext();
+      const serve = decideServe(ctx, rng, cfg);
+      expect(serve.targetPosition.y).toBeLessThanOrEqual(0);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DefaultPlayerEngine class tests
+// ---------------------------------------------------------------------------
+
+describe("DefaultPlayerEngine", () => {
+  it("implements PlayerEngine interface correctly", () => {
+    const rng = makeRng();
+    const engine = new DefaultPlayerEngine(makeAttacker(), rng);
+
+    const shotCtx = makeShotContext();
+    const shot = engine.decideShot(shotCtx);
+    expect(shot).toBeDefined();
+    expect(shot.side).toBeDefined();
+    expect(shot.power).toBeGreaterThanOrEqual(0);
+
+    const serveCtx = makeServeContext();
+    const serve = engine.decideServe(serveCtx);
+    expect(serve).toBeDefined();
+    expect(serve.side).toBeDefined();
+
+    // Lifecycle hooks should not throw
+    engine.onPointEnd({ winner: "Zhang Wei", server: "Zhang Wei", rallyLength: 3, reason: "unreturnable" });
+    engine.onGameEnd("Zhang Wei");
+    engine.onTimeout();
+  });
+
+  it("factory creates working engine instances", () => {
+    const rng = makeRng();
+    const factory = createDefaultPlayerEngineFactory(rng);
+
+    const attackerEngine = factory(makeAttacker());
+    const chopperEngine = factory(makeChopper());
+
+    expect(attackerEngine).toBeInstanceOf(DefaultPlayerEngine);
+    expect(chopperEngine).toBeInstanceOf(DefaultPlayerEngine);
+
+    const ctx = makeShotContext();
+    const attackerShot = attackerEngine.decideShot(ctx);
+    const chopperShot = chopperEngine.decideShot({ ...ctx, player: makeChopper() });
+
+    expect(attackerShot).toBeDefined();
+    expect(chopperShot).toBeDefined();
+  });
+});

--- a/src/engine/player/__tests__/player-engine.test.ts
+++ b/src/engine/player/__tests__/player-engine.test.ts
@@ -430,24 +430,33 @@ describe("target-placement", () => {
     expect(leftCount).toBeGreaterThan(100);
   });
 
-  it("serve targets are on receiver half", () => {
+  it("serve targets are on receiver half (server at +Y)", () => {
     for (let seed = 0; seed < 50; seed++) {
       const rng = makeRng(seed);
-      const target = computeServeTarget(0.5, 0.5, rng, cfg);
+      const target = computeServeTarget(0.5, 0.5, 160, rng, cfg);
       expect(target.y).toBeLessThanOrEqual(0);
       expect(target.y).toBeGreaterThanOrEqual(-cfg.tableHalfLength);
     }
   });
 
+  it("serve targets are on receiver half (server at -Y)", () => {
+    for (let seed = 0; seed < 50; seed++) {
+      const rng = makeRng(seed);
+      const target = computeServeTarget(0.5, 0.5, -160, rng, cfg);
+      expect(target.y).toBeGreaterThanOrEqual(0);
+      expect(target.y).toBeLessThanOrEqual(cfg.tableHalfLength);
+    }
+  });
+
   it("short serve tendency targets near net", () => {
     const rng = makeRng();
-    const target = computeServeTarget(0, 0.3, rng, cfg);
+    const target = computeServeTarget(0, 0.3, 160, rng, cfg);
     expect(target.y).toBeGreaterThan(-60);
   });
 
   it("long serve tendency targets near end line", () => {
     const rng = makeRng();
-    const target = computeServeTarget(1, 0.3, rng, cfg);
+    const target = computeServeTarget(1, 0.3, 160, rng, cfg);
     expect(target.y).toBeLessThan(-100);
   });
 });

--- a/src/engine/player/constants.ts
+++ b/src/engine/player/constants.ts
@@ -1,0 +1,125 @@
+/**
+ * Player engine configuration — every balance-affecting value lives here.
+ *
+ * To tweak balance:
+ * 1. Edit DEFAULT_PLAYER_ENGINE_CONFIG below, or
+ * 2. Pass Partial<PlayerEngineConfig> overrides to the factory / constructor.
+ *
+ * No magic numbers anywhere else in the player engine code.
+ */
+
+export interface PlayerEngineConfig {
+  // --- Tendency mapping ---
+  /** Standard deviation for per-shot Gaussian variation (fraction of tendency). */
+  tendencyVariationStddev: number;
+
+  // --- Net clearance mapping ---
+  /** Minimum net clearance in cm (tendency=0, net-skimming). */
+  minNetClearance: number;
+  /** Maximum net clearance in cm (tendency=100, high arc). */
+  maxNetClearance: number;
+
+  // --- Table geometry (derived from physics, duplicated for independence) ---
+  /** Half-length of the table in cm (Y direction). */
+  tableHalfLength: number;
+  /** Half-width of the table in cm (X direction). */
+  tableHalfWidth: number;
+
+  // --- Target placement ---
+  /** Margin from table edge for safest placement (cm). */
+  safeMargin: number;
+  /** Minimum margin from table edge even at maximum risk (cm). */
+  minEdgeMargin: number;
+  /** Weight for targeting away from opponent (0-1). */
+  opponentAvoidanceWeight: number;
+
+  // --- Depth placement ---
+  /** Shortest shot: fraction of opponent half-table depth from net. */
+  shortDepthFraction: number;
+  /** Deepest shot: fraction of opponent half-table depth from net. */
+  deepDepthFraction: number;
+
+  // --- Recovery ---
+  /** Ready position depth: distance from table center along Y (cm). */
+  readyPositionDepth: number;
+  /** How much recovery target shifts toward anticipated return (fraction). */
+  recoveryAnticipationFraction: number;
+
+  // --- Pressure modifiers ---
+  /** Maximum risk adjustment under pressure (absolute, added/subtracted). */
+  pressureRiskAdjustment: number;
+  /** Mental score at which pressure effect is neutral (0-100). */
+  mentalPressureThreshold: number;
+
+  // --- Positional safety ---
+  /** Positional deficit above which the engine forces safer play (0-1). */
+  safetyDeficitThreshold: number;
+  /** Risk reduction multiplier when deficit exceeds threshold (0-1). */
+  deficitRiskReduction: number;
+
+  // --- Side selection ---
+  /** Weight for capability-based preference vs randomness (0-1). */
+  strongSidePreferenceWeight: number;
+
+  // --- Risk amplification ---
+  /** How much risk amplifies tendency values toward extremes. */
+  riskAmplification: number;
+
+  // --- Serve ---
+  /** Maximum serve net clearance (cm above net). */
+  maxServeNetClearance: number;
+  /** Serve width range as fraction of table half-width. */
+  serveWidthRange: number;
+}
+
+export const DEFAULT_PLAYER_ENGINE_CONFIG: PlayerEngineConfig = {
+  // Tendency mapping
+  tendencyVariationStddev: 0.08,
+
+  // Net clearance
+  minNetClearance: 1.0,
+  maxNetClearance: 25.0,
+
+  // Table geometry
+  tableHalfLength: 137,
+  tableHalfWidth: 76.25,
+
+  // Target placement
+  safeMargin: 15,
+  minEdgeMargin: 3,
+  opponentAvoidanceWeight: 0.6,
+
+  // Depth placement
+  shortDepthFraction: 0.2,
+  deepDepthFraction: 0.95,
+
+  // Recovery
+  readyPositionDepth: 160,
+  recoveryAnticipationFraction: 0.2,
+
+  // Pressure modifiers
+  pressureRiskAdjustment: 0.15,
+  mentalPressureThreshold: 50,
+
+  // Positional safety
+  safetyDeficitThreshold: 0.5,
+  deficitRiskReduction: 0.5,
+
+  // Side selection
+  strongSidePreferenceWeight: 0.3,
+
+  // Risk amplification
+  riskAmplification: 0.3,
+
+  // Serve
+  maxServeNetClearance: 8.0,
+  serveWidthRange: 0.8,
+};
+
+/** Merge a partial config with defaults. */
+export function mergePlayerConfig(
+  overrides?: Partial<PlayerEngineConfig>,
+): PlayerEngineConfig {
+  if (!overrides) return { ...DEFAULT_PLAYER_ENGINE_CONFIG };
+  return { ...DEFAULT_PLAYER_ENGINE_CONFIG, ...overrides };
+}

--- a/src/engine/player/constants.ts
+++ b/src/engine/player/constants.ts
@@ -78,6 +78,34 @@ export interface PlayerEngineConfig {
   deceptionRiskScale: number;
   /** Gaussian noise stddev for per-shot deception variation. */
   deceptionNoiseStddev: number;
+
+  // --- Spin direction noise ---
+  /** Gaussian stddev for rally topspin direction noise. */
+  topspinNoiseStddev: number;
+  /** Gaussian stddev factor for rally sidespin direction noise. */
+  sidespinNoiseStddev: number;
+  /** Gaussian noise scale for serve topspin variation (multiplied by spinVariation). */
+  serveTopspinVariationScale: number;
+  /** Gaussian noise scale for serve sidespin variation (multiplied by spinVariation). */
+  serveSidespinVariationScale: number;
+
+  // --- Net clearance noise ---
+  /** How much risk reduces net clearance (0-1 fraction). */
+  netClearanceRiskReduction: number;
+  /** Gaussian stddev for rally net clearance noise (cm). */
+  shotClearanceNoiseStddev: number;
+  /** Gaussian stddev for serve net clearance noise (cm). */
+  serveClearanceNoiseStddev: number;
+
+  // --- Target placement noise ---
+  /** Width noise scale relative to maxX for rally shots. */
+  targetWidthNoiseScale: number;
+  /** Per-shot jitter stddev for rally target position (cm). */
+  targetJitterStddev: number;
+  /** Width noise scale relative to effectiveMaxX for serves. */
+  serveWidthNoiseScale: number;
+  /** Per-shot jitter stddev for serve target position (cm). */
+  serveJitterStddev: number;
 }
 
 export const DEFAULT_PLAYER_ENGINE_CONFIG: PlayerEngineConfig = {
@@ -127,6 +155,23 @@ export const DEFAULT_PLAYER_ENGINE_CONFIG: PlayerEngineConfig = {
   deceptionBaseScale: 0.5,
   deceptionRiskScale: 0.5,
   deceptionNoiseStddev: 0.05,
+
+  // Spin direction noise
+  topspinNoiseStddev: 0.1,
+  sidespinNoiseStddev: 0.7,
+  serveTopspinVariationScale: 0.5,
+  serveSidespinVariationScale: 0.3,
+
+  // Net clearance noise
+  netClearanceRiskReduction: 0.3,
+  shotClearanceNoiseStddev: 1.0,
+  serveClearanceNoiseStddev: 0.5,
+
+  // Target placement noise
+  targetWidthNoiseScale: 0.3,
+  targetJitterStddev: 3.0,
+  serveWidthNoiseScale: 0.5,
+  serveJitterStddev: 2.0,
 };
 
 /** Merge a partial config with defaults. */

--- a/src/engine/player/constants.ts
+++ b/src/engine/player/constants.ts
@@ -70,6 +70,14 @@ export interface PlayerEngineConfig {
   maxServeNetClearance: number;
   /** Serve width range as fraction of table half-width. */
   serveWidthRange: number;
+
+  // --- Deception ---
+  /** Base deception scale — how much of the deception attribute is used at zero risk. */
+  deceptionBaseScale: number;
+  /** Additional deception scale applied per unit of effective risk. */
+  deceptionRiskScale: number;
+  /** Gaussian noise stddev for per-shot deception variation. */
+  deceptionNoiseStddev: number;
 }
 
 export const DEFAULT_PLAYER_ENGINE_CONFIG: PlayerEngineConfig = {
@@ -114,6 +122,11 @@ export const DEFAULT_PLAYER_ENGINE_CONFIG: PlayerEngineConfig = {
   // Serve
   maxServeNetClearance: 8.0,
   serveWidthRange: 0.8,
+
+  // Deception
+  deceptionBaseScale: 0.5,
+  deceptionRiskScale: 0.5,
+  deceptionNoiseStddev: 0.05,
 };
 
 /** Merge a partial config with defaults. */

--- a/src/engine/player/index.ts
+++ b/src/engine/player/index.ts
@@ -1,0 +1,72 @@
+/**
+ * DefaultPlayerEngine — tendency-based player decision-making.
+ *
+ * Implements the PlayerEngine interface using the player's stroke/serve
+ * tendencies and attributes. Inject a seedable Rng for deterministic
+ * simulation.
+ *
+ * Lifecycle hooks (onPointEnd, onGameEnd, onTimeout) are stubbed — future
+ * features (adaptation, fatigue, momentum) will populate them.
+ */
+
+import type {
+  PlayerEngine,
+  PlayerEngineFactory,
+  ShotContext,
+  ServeContext,
+  ShotIntention,
+  ServeIntention,
+  PointSummary,
+} from "../types/index.js";
+import type { Player } from "../types/index.js";
+import type { Rng } from "../rng.js";
+import type { PlayerEngineConfig } from "./constants.js";
+import { mergePlayerConfig } from "./constants.js";
+import { decideShot } from "./shot-decision.js";
+import { decideServe } from "./serve-decision.js";
+
+export class DefaultPlayerEngine implements PlayerEngine {
+  private readonly player: Player;
+  private readonly rng: Rng;
+  private readonly config: PlayerEngineConfig;
+
+  constructor(player: Player, rng: Rng, config?: Partial<PlayerEngineConfig>) {
+    this.player = player;
+    this.rng = rng;
+    this.config = mergePlayerConfig(config);
+  }
+
+  decideServe(context: ServeContext): ServeIntention {
+    return decideServe(context, this.rng, this.config);
+  }
+
+  decideShot(context: ShotContext): ShotIntention {
+    return decideShot(context, this.rng, this.config);
+  }
+
+  onPointEnd(_result: PointSummary): void {
+    // Future: update momentum, adaptation state, fatigue
+  }
+
+  onGameEnd(_gameWinner: string): void {
+    // Future: between-game mental reset, partial stamina recovery
+  }
+
+  onTimeout(): void {
+    // Future: mental reset, partial recovery
+  }
+}
+
+/**
+ * Create a factory that produces DefaultPlayerEngine instances.
+ *
+ * The Rng is captured by the closure and shared across all player engines
+ * created by this factory — both players consume from the same deterministic
+ * stream, ensuring seed reproducibility.
+ */
+export function createDefaultPlayerEngineFactory(
+  rng: Rng,
+  config?: Partial<PlayerEngineConfig>,
+): PlayerEngineFactory {
+  return (player: Player) => new DefaultPlayerEngine(player, rng, config);
+}

--- a/src/engine/player/index.ts
+++ b/src/engine/player/index.ts
@@ -10,6 +10,7 @@
  */
 
 import type {
+  Player,
   PlayerEngine,
   PlayerEngineFactory,
   ShotContext,
@@ -18,7 +19,6 @@ import type {
   ServeIntention,
   PointSummary,
 } from "../types/index.js";
-import type { Player } from "../types/index.js";
 import type { Rng } from "../rng.js";
 import type { PlayerEngineConfig } from "./constants.js";
 import { mergePlayerConfig } from "./constants.js";

--- a/src/engine/player/serve-decision.ts
+++ b/src/engine/player/serve-decision.ts
@@ -74,7 +74,7 @@ export function decideServe(
   // spinVariation controls per-serve noise on direction
   const variationScale = tendencies.spinVariation / 100;
   const topspin = clamp(
-    topspinBase + rng.gaussian(0, variationScale * 0.5),
+    topspinBase + rng.gaussian(0, variationScale * config.serveTopspinVariationScale),
     -1,
     1,
   );
@@ -83,7 +83,7 @@ export function decideServe(
   const sidespinBase = tendencies.sidespinBias / 100;
   const sidespinSign = rng.next() > 0.5 ? 1 : -1;
   const sidespin = clamp(
-    sidespinBase * sidespinSign + rng.gaussian(0, variationScale * 0.3),
+    sidespinBase * sidespinSign + rng.gaussian(0, variationScale * config.serveSidespinVariationScale),
     -1,
     1,
   );
@@ -102,7 +102,7 @@ export function decideServe(
   let netClearance =
     config.minNetClearance +
     (1 - effectiveRisk) * (config.maxServeNetClearance - config.minNetClearance);
-  netClearance += rng.gaussian(0, 0.5);
+  netClearance += rng.gaussian(0, config.serveClearanceNoiseStddev);
   netClearance = Math.max(config.minNetClearance, netClearance);
 
   // --- Step 8: Deception Effort ---

--- a/src/engine/player/serve-decision.ts
+++ b/src/engine/player/serve-decision.ts
@@ -93,6 +93,7 @@ export function decideServe(
   const targetPosition = computeServeTarget(
     lengthMapped,
     effectiveRisk,
+    context.playerPosition.y,
     rng,
     config,
   );

--- a/src/engine/player/serve-decision.ts
+++ b/src/engine/player/serve-decision.ts
@@ -1,0 +1,129 @@
+/**
+ * Serve decision algorithm.
+ *
+ * Translates a ServeContext into a ServeIntention using the player's
+ * serve tendencies, capabilities, and attributes.
+ */
+
+import type { ServeContext, ServeIntention } from "../types/index.js";
+import type { Rng } from "../rng.js";
+import type { PlayerEngineConfig } from "./constants.js";
+import { clamp } from "../physics/vec-math.js";
+import { mapTendency, mapTendencyWithRisk } from "./tendency-mapper.js";
+import { selectSide } from "./side-selection.js";
+import { computeServeTarget } from "./target-placement.js";
+
+/**
+ * Decide a serve based on context and serve tendencies.
+ *
+ * Steps:
+ * 1. Compute effective risk (base tendency + pressure)
+ * 2. Select paddle side (both available for serves)
+ * 3. Map power, spin intensity, spin direction, target, clearance, deception
+ */
+export function decideServe(
+  context: ServeContext,
+  rng: Rng,
+  config: PlayerEngineConfig,
+): ServeIntention {
+  const { serveTendencies: tendencies, attributes } = context.player;
+
+  // --- Step 1: Effective Risk ---
+  let effectiveRisk = mapTendency(tendencies.risk, rng, config);
+
+  const isPressure =
+    context.matchState.isMatchPoint ||
+    context.matchState.isGamePoint ||
+    context.matchState.isDeuce;
+
+  if (isPressure) {
+    const mentalFactor =
+      (attributes.mental - config.mentalPressureThreshold) / 100;
+    effectiveRisk = clamp(
+      effectiveRisk - mentalFactor * config.pressureRiskAdjustment,
+      0,
+      1,
+    );
+  }
+
+  // --- Step 2: Side Selection ---
+  // Both sides available for serves
+  const side = selectSide(
+    ["forehand", "backhand"],
+    context.player.strokeCapabilities,
+    rng,
+    config,
+  );
+
+  // --- Step 3: Power ---
+  const power = mapTendencyWithRisk(
+    tendencies.speed,
+    effectiveRisk,
+    rng,
+    config,
+  );
+
+  // --- Step 4: Spin Intensity ---
+  const spinIntensity = mapTendencyWithRisk(
+    tendencies.spinAmount,
+    effectiveRisk,
+    rng,
+    config,
+  );
+
+  // --- Step 5: Spin Direction ---
+  // backspinBias: 0=topspin, 50=mixed, 100=backspin
+  // Map to topspin axis: 0→+1, 50→0, 100→-1
+  const topspinBase = (50 - tendencies.backspinBias) / 50;
+  // spinVariation controls per-serve noise on direction
+  const variationScale = tendencies.spinVariation / 100;
+  const topspin = clamp(
+    topspinBase + rng.gaussian(0, variationScale * 0.5),
+    -1,
+    1,
+  );
+
+  // sidespinBias: magnitude, random sign per serve
+  const sidespinBase = tendencies.sidespinBias / 100;
+  const sidespinSign = rng.next() > 0.5 ? 1 : -1;
+  const sidespin = clamp(
+    sidespinBase * sidespinSign + rng.gaussian(0, variationScale * 0.3),
+    -1,
+    1,
+  );
+
+  // --- Step 6: Target Position ---
+  const lengthMapped = mapTendency(tendencies.length, rng, config);
+  const targetPosition = computeServeTarget(
+    lengthMapped,
+    effectiveRisk,
+    rng,
+    config,
+  );
+
+  // --- Step 7: Net Clearance ---
+  // Serves typically skim the net. Higher risk = lower clearance.
+  let netClearance =
+    config.minNetClearance +
+    (1 - effectiveRisk) * (config.maxServeNetClearance - config.minNetClearance);
+  netClearance += rng.gaussian(0, 0.5);
+  netClearance = Math.max(config.minNetClearance, netClearance);
+
+  // --- Step 8: Deception Effort ---
+  const deceptionBase = attributes.deception / 100;
+  const deceptionEffort = clamp(
+    deceptionBase * (0.5 + effectiveRisk * 0.5) + rng.gaussian(0, 0.05),
+    0,
+    1,
+  );
+
+  return {
+    side,
+    power,
+    spinIntensity,
+    spinDirection: { topspin, sidespin },
+    targetPosition,
+    netClearance,
+    deceptionEffort,
+  };
+}

--- a/src/engine/player/shot-decision.ts
+++ b/src/engine/player/shot-decision.ts
@@ -82,11 +82,11 @@ export function decideShot(
   // --- Step 5: Spin Direction ---
   // topspinBias: 0=backspin dominant, 50=flat, 100=topspin dominant → [-1, 1]
   const topspinBase = (tendencies.topspinBias - 50) / 50;
-  const topspin = clamp(topspinBase + rng.gaussian(0, 0.1), -1, 1);
+  const topspin = clamp(topspinBase + rng.gaussian(0, config.topspinNoiseStddev), -1, 1);
 
   // sidespinUsage: magnitude with random direction per shot
   const sidespinMag = tendencies.sidespinUsage / 100;
-  const sidespin = clamp(sidespinMag * rng.gaussian(0, 0.7), -1, 1);
+  const sidespin = clamp(sidespinMag * rng.gaussian(0, config.sidespinNoiseStddev), -1, 1);
 
   // --- Step 6: Target Position ---
   const depthMapped = mapTendency(tendencies.depthBias, rng, config);
@@ -105,8 +105,8 @@ export function decideShot(
     config.minNetClearance +
     netClearanceBase * (config.maxNetClearance - config.minNetClearance);
   // Risk reduces clearance (aggressive players skim the net more)
-  netClearanceCm *= 1 - effectiveRisk * 0.3;
-  netClearanceCm += rng.gaussian(0, 1.0);
+  netClearanceCm *= 1 - effectiveRisk * config.netClearanceRiskReduction;
+  netClearanceCm += rng.gaussian(0, config.shotClearanceNoiseStddev);
   netClearanceCm = Math.max(config.minNetClearance, netClearanceCm);
 
   // --- Step 8: Deception Effort ---

--- a/src/engine/player/shot-decision.ts
+++ b/src/engine/player/shot-decision.ts
@@ -1,0 +1,145 @@
+/**
+ * Rally shot decision algorithm.
+ *
+ * Translates a ShotContext into a ShotIntention using the player's
+ * stroke tendencies, capabilities, and attributes. Per-shot variation
+ * comes from the seedable RNG.
+ */
+
+import type { ShotContext, ShotIntention } from "../types/index.js";
+import type { Rng } from "../rng.js";
+import type { PlayerEngineConfig } from "./constants.js";
+import { clamp } from "../physics/vec-math.js";
+import { mapTendency, mapTendencyWithRisk } from "./tendency-mapper.js";
+import { selectSide } from "./side-selection.js";
+import { computeTargetPosition } from "./target-placement.js";
+
+/**
+ * Decide a rally shot based on context and player tendencies.
+ *
+ * Steps:
+ * 1. Compute effective risk (base tendency + pressure + positional safety)
+ * 2. Select paddle side
+ * 3. Map power, spin, direction, target, clearance, deception
+ * 4. Compute recovery target
+ */
+export function decideShot(
+  context: ShotContext,
+  rng: Rng,
+  config: PlayerEngineConfig,
+): ShotIntention {
+  const { strokeTendencies: tendencies, attributes } = context.player;
+  const arrival = context.arrival;
+
+  // --- Step 1: Effective Risk ---
+  let effectiveRisk = mapTendency(tendencies.riskTolerance, rng, config);
+
+  // Pressure adjustment
+  const isPressure =
+    context.matchState.isMatchPoint ||
+    context.matchState.isGamePoint ||
+    context.matchState.isDeuce;
+
+  if (isPressure) {
+    // mentalFactor > 0 for high-mental players (reduces risk = stays calm)
+    // mentalFactor < 0 for low-mental players (increases risk = panics)
+    const mentalFactor =
+      (attributes.mental - config.mentalPressureThreshold) / 100;
+    effectiveRisk = clamp(
+      effectiveRisk - mentalFactor * config.pressureRiskAdjustment,
+      0,
+      1,
+    );
+  }
+
+  // Positional safety: when stretched, play safer
+  if (arrival.positionalDeficit > config.safetyDeficitThreshold) {
+    const deficit =
+      (arrival.positionalDeficit - config.safetyDeficitThreshold) /
+      (1 - config.safetyDeficitThreshold);
+    effectiveRisk *= 1 - deficit * config.deficitRiskReduction;
+  }
+
+  effectiveRisk = clamp(effectiveRisk, 0, 1);
+
+  // --- Step 2: Side Selection ---
+  const side = selectSide(
+    arrival.availableSides,
+    context.player.strokeCapabilities,
+    rng,
+    config,
+  );
+
+  // --- Step 3: Power ---
+  const power = mapTendencyWithRisk(
+    tendencies.powerBias,
+    effectiveRisk,
+    rng,
+    config,
+  );
+
+  // --- Step 4: Spin Intensity ---
+  const spinIntensity = mapTendencyWithRisk(
+    tendencies.spinIntensity,
+    effectiveRisk,
+    rng,
+    config,
+  );
+
+  // --- Step 5: Spin Direction ---
+  // topspinBias: 0=backspin dominant, 50=flat, 100=topspin dominant → [-1, 1]
+  const topspinBase = (tendencies.topspinBias - 50) / 50;
+  const topspin = clamp(topspinBase + rng.gaussian(0, 0.1), -1, 1);
+
+  // sidespinUsage: magnitude with random direction per shot
+  const sidespinMag = tendencies.sidespinUsage / 100;
+  const sidespin = clamp(sidespinMag * rng.gaussian(0, 0.7), -1, 1);
+
+  // --- Step 6: Target Position ---
+  const depthMapped = mapTendency(tendencies.depthBias, rng, config);
+  const targetPosition = computeTargetPosition(
+    depthMapped,
+    effectiveRisk,
+    context.opponentPosition,
+    context.playerPosition.y,
+    rng,
+    config,
+  );
+
+  // --- Step 7: Net Clearance ---
+  const netClearanceBase = tendencies.netClearance / 100;
+  let netClearanceCm =
+    config.minNetClearance +
+    netClearanceBase * (config.maxNetClearance - config.minNetClearance);
+  // Risk reduces clearance (aggressive players skim the net more)
+  netClearanceCm *= 1 - effectiveRisk * 0.3;
+  netClearanceCm += rng.gaussian(0, 1.0);
+  netClearanceCm = Math.max(config.minNetClearance, netClearanceCm);
+
+  // --- Step 8: Deception Effort ---
+  const deceptionBase = attributes.deception / 100;
+  const deceptionEffort = clamp(
+    deceptionBase * (0.5 + effectiveRisk * 0.5) + rng.gaussian(0, 0.05),
+    0,
+    1,
+  );
+
+  // --- Step 9: Recovery Target ---
+  const playerEndSign = context.playerPosition.y >= 0 ? 1 : -1;
+  const readyY = playerEndSign * config.readyPositionDepth;
+  // Anticipate return: shift slightly opposite to where we aimed
+  const anticipateX =
+    -targetPosition.x * config.recoveryAnticipationFraction;
+  const recoveryTarget = { x: anticipateX, y: readyY };
+
+  return {
+    side,
+    power,
+    spinIntensity,
+    spinDirection: { topspin, sidespin },
+    targetPosition,
+    netClearance: netClearanceCm,
+    deceptionEffort,
+    recoveryTarget,
+  };
+}

--- a/src/engine/player/side-selection.ts
+++ b/src/engine/player/side-selection.ts
@@ -1,0 +1,41 @@
+/**
+ * Forehand/backhand selection logic.
+ *
+ * Picks the paddle side based on capability scores with a random
+ * perturbation so choices aren't perfectly deterministic.
+ */
+
+import type { StrokeSide, StrokeCapabilities } from "../types/index.js";
+import type { Rng } from "../rng.js";
+import type { PlayerEngineConfig } from "./constants.js";
+
+/**
+ * Select which paddle side to use from the available sides.
+ *
+ * If only one side is available, returns it.
+ * Otherwise scores each side by capability average (power + spin + accuracy
+ * + consistency) weighted by `strongSidePreferenceWeight`, plus a random
+ * component. The higher-scoring side wins.
+ */
+export function selectSide(
+  availableSides: StrokeSide[],
+  capabilities: StrokeCapabilities,
+  rng: Rng,
+  config: PlayerEngineConfig,
+): StrokeSide {
+  if (availableSides.length === 1) return availableSides[0];
+
+  const prefWeight = config.strongSidePreferenceWeight;
+
+  function sideScore(side: StrokeSide): number {
+    const caps = capabilities[side];
+    const base =
+      (caps.powerCeiling + caps.spinCeiling + caps.accuracy + caps.consistency) / 4;
+    return base * prefWeight + rng.next() * (1 - prefWeight) * 100;
+  }
+
+  const fhScore = sideScore("forehand");
+  const bhScore = sideScore("backhand");
+
+  return fhScore >= bhScore ? "forehand" : "backhand";
+}

--- a/src/engine/player/target-placement.ts
+++ b/src/engine/player/target-placement.ts
@@ -50,12 +50,12 @@ export function computeTargetPosition(
   const oppX = opponentPosition.x;
   const targetSide = oppX >= 0 ? -1 : 1;
   const baseX = targetSide * maxX * config.opponentAvoidanceWeight;
-  const randomX = rng.gaussian(0, maxX * 0.3);
+  const randomX = rng.gaussian(0, maxX * config.targetWidthNoiseScale);
   let targetX = baseX + randomX;
 
   // Per-shot jitter
-  targetX += rng.gaussian(0, 3.0);
-  targetY += targetSign * rng.gaussian(0, 3.0);
+  targetX += rng.gaussian(0, config.targetJitterStddev);
+  targetY += targetSign * rng.gaussian(0, config.targetJitterStddev);
 
   // Clamp to valid table area on opponent's half
   targetX = clamp(targetX, -config.tableHalfWidth, config.tableHalfWidth);
@@ -96,11 +96,11 @@ export function computeServeTarget(
   const effectiveMaxX = Math.min(maxX, config.tableHalfWidth - effectiveMargin);
 
   // Random X placement within range
-  let targetX = rng.gaussian(0, effectiveMaxX * 0.5);
+  let targetX = rng.gaussian(0, effectiveMaxX * config.serveWidthNoiseScale);
 
   // Per-shot jitter
-  targetX += rng.gaussian(0, 2.0);
-  targetY += rng.gaussian(0, 2.0);
+  targetX += rng.gaussian(0, config.serveJitterStddev);
+  targetY += rng.gaussian(0, config.serveJitterStddev);
 
   // Clamp
   targetX = clamp(targetX, -config.tableHalfWidth, config.tableHalfWidth);

--- a/src/engine/player/target-placement.ts
+++ b/src/engine/player/target-placement.ts
@@ -1,0 +1,110 @@
+/**
+ * Target position computation for rally shots and serves.
+ *
+ * All coordinates in cm, origin at table center.
+ * The player's side is determined by the sign of playerY:
+ *   +Y player targets -Y half (opponent's side)
+ *   -Y player targets +Y half (opponent's side)
+ */
+
+import type { Vec2 } from "../types/index.js";
+import type { Rng } from "../rng.js";
+import type { PlayerEngineConfig } from "./constants.js";
+import { clamp } from "../physics/vec-math.js";
+
+/**
+ * Compute target position on the opponent's half of the table.
+ *
+ * @param depthBias - Mapped depth tendency (0-1). 0=short, 1=deep.
+ * @param riskFactor - Effective risk tolerance (0-1). Higher=tighter margins.
+ * @param opponentPosition - Opponent's court position.
+ * @param playerY - This player's Y position (sign determines which half to target).
+ * @param rng - Seedable RNG.
+ * @param config - Player engine config.
+ * @returns Target position in table coordinates (cm).
+ */
+export function computeTargetPosition(
+  depthBias: number,
+  riskFactor: number,
+  opponentPosition: Vec2,
+  playerY: number,
+  rng: Rng,
+  config: PlayerEngineConfig,
+): Vec2 {
+  // Target the opposite half from the player
+  const targetSign = playerY >= 0 ? -1 : 1;
+
+  // --- Depth (Y) ---
+  const shortY = config.shortDepthFraction * config.tableHalfLength;
+  const deepY = config.deepDepthFraction * config.tableHalfLength;
+  const depthMag = shortY + depthBias * (deepY - shortY);
+  let targetY = targetSign * depthMag;
+
+  // --- Width (X) ---
+  // Edge margin narrows with higher risk
+  const effectiveMargin =
+    config.safeMargin - riskFactor * (config.safeMargin - config.minEdgeMargin);
+  const maxX = config.tableHalfWidth - effectiveMargin;
+
+  // Bias away from opponent's X position
+  const oppX = opponentPosition.x;
+  const targetSide = oppX >= 0 ? -1 : 1;
+  const baseX = targetSide * maxX * config.opponentAvoidanceWeight;
+  const randomX = rng.gaussian(0, maxX * 0.3);
+  let targetX = baseX + randomX;
+
+  // Per-shot jitter
+  targetX += rng.gaussian(0, 3.0);
+  targetY += targetSign * rng.gaussian(0, 3.0);
+
+  // Clamp to valid table area on opponent's half
+  targetX = clamp(targetX, -config.tableHalfWidth, config.tableHalfWidth);
+  if (targetSign < 0) {
+    targetY = clamp(targetY, -config.tableHalfLength, 0);
+  } else {
+    targetY = clamp(targetY, 0, config.tableHalfLength);
+  }
+
+  return { x: targetX, y: targetY };
+}
+
+/**
+ * Compute serve target position on the receiver's half.
+ *
+ * @param lengthTendency - Mapped serve length tendency (0-1). 0=short, 1=long.
+ * @param riskFactor - Mapped serve risk (0-1).
+ * @param rng - Seedable RNG.
+ * @param config - Player engine config.
+ * @returns Target position on receiver's half (always -Y, server is at +Y).
+ */
+export function computeServeTarget(
+  lengthTendency: number,
+  riskFactor: number,
+  rng: Rng,
+  config: PlayerEngineConfig,
+): Vec2 {
+  // Server is always at +Y, so serves target -Y half
+  const shortY = config.shortDepthFraction * config.tableHalfLength;
+  const deepY = config.deepDepthFraction * config.tableHalfLength;
+  const depthMag = shortY + lengthTendency * (deepY - shortY);
+  let targetY = -depthMag;
+
+  // Width: use serve-specific range
+  const maxX = config.tableHalfWidth * config.serveWidthRange;
+  const effectiveMargin =
+    config.safeMargin - riskFactor * (config.safeMargin - config.minEdgeMargin);
+  const effectiveMaxX = Math.min(maxX, config.tableHalfWidth - effectiveMargin);
+
+  // Random X placement within range
+  let targetX = rng.gaussian(0, effectiveMaxX * 0.5);
+
+  // Per-shot jitter
+  targetX += rng.gaussian(0, 2.0);
+  targetY += rng.gaussian(0, 2.0);
+
+  // Clamp
+  targetX = clamp(targetX, -config.tableHalfWidth, config.tableHalfWidth);
+  targetY = clamp(targetY, -config.tableHalfLength, 0);
+
+  return { x: targetX, y: targetY };
+}

--- a/src/engine/player/tendency-mapper.ts
+++ b/src/engine/player/tendency-mapper.ts
@@ -1,0 +1,50 @@
+/**
+ * Maps player tendencies (0-100 scale) to shot parameters (0-1 scale)
+ * with per-shot Gaussian variation for natural shot-to-shot diversity.
+ */
+
+import type { Rng } from "../rng.js";
+import type { PlayerEngineConfig } from "./constants.js";
+import { clamp } from "../physics/vec-math.js";
+
+/**
+ * Map a 0-100 tendency to a 0-1 parameter with per-shot Gaussian variation.
+ *
+ * @param tendency - Base tendency value (0-100)
+ * @param rng - Seedable RNG
+ * @param config - Player engine config (for stddev)
+ * @returns Value in [0, 1]
+ */
+export function mapTendency(
+  tendency: number,
+  rng: Rng,
+  config: PlayerEngineConfig,
+): number {
+  const base = tendency / 100;
+  const variation = rng.gaussian(0, config.tendencyVariationStddev);
+  return clamp(base + variation, 0, 1);
+}
+
+/**
+ * Map a tendency with a risk modifier. Higher risk pushes the value
+ * further from 0.5 (amplifies the player's natural tendency).
+ *
+ * @param tendency - Base tendency (0-100)
+ * @param riskFactor - Effective risk tolerance (0-1)
+ * @param rng - Seedable RNG
+ * @param config - Player engine config
+ * @returns Value in [0, 1]
+ */
+export function mapTendencyWithRisk(
+  tendency: number,
+  riskFactor: number,
+  rng: Rng,
+  config: PlayerEngineConfig,
+): number {
+  const base = tendency / 100;
+  // Risk amplifies tendency away from center:
+  // a powerBias of 0.7 at high risk pushes toward ~0.76
+  const amplified = base + (base - 0.5) * riskFactor * config.riskAmplification;
+  const variation = rng.gaussian(0, config.tendencyVariationStddev);
+  return clamp(amplified + variation, 0, 1);
+}


### PR DESCRIPTION
## Summary
- Implement the default player engine that translates game state into shot/serve intentions using player tendencies, capabilities, and attributes
- Tendency-based decision-making with per-shot RNG variation for natural shot diversity
- Pressure awareness (mental attribute adjusts risk under deuce/game point/match point), positional safety (high deficit forces safer play), opponent-aware targeting
- Configurable via PlayerEngineConfig (follows same pattern as PhysicsConfig)
- 31 tests covering tendency mapping, side selection, target placement, shot/serve decisions, playstyle differentiation, and determinism

## Structure
- `constants.ts` — PlayerEngineConfig + defaults
- `tendency-mapper.ts` — Maps 0-100 tendencies to 0-1 parameters with Gaussian variation
- `side-selection.ts` — Forehand/backhand selection by capability scoring
- `target-placement.ts` — Shot and serve target position computation
- `shot-decision.ts` — Rally shot decision algorithm
- `serve-decision.ts` — Serve decision algorithm
- `index.ts` — DefaultPlayerEngine class + factory

## Test plan
- [x] All 31 player engine tests pass
- [x] All 72 tests pass (41 physics + 31 player engine)
- [x] Attacker produces higher power, more topspin, lower net clearance than chopper
- [x] Chopper produces more backspin, higher net clearance
- [x] Pressure + mental attribute correctly adjusts risk
- [x] High positional deficit reduces risk (safer play)
- [x] Deterministic with same seed