### PR TITLE
Add spin read & deception system

### DIFF
--- a/src/engine/player/constants.ts
+++ b/src/engine/player/constants.ts
@@ -106,6 +106,22 @@ export interface PlayerEngineConfig {
   serveWidthNoiseScale: number;
   /** Per-shot jitter stddev for serve target position (cm). */
   serveJitterStddev: number;
+
+  // --- Spin read ---
+  /** Scale factor for read difficulty (deception attribute × effort × scale). */
+  readDifficultyScale: number;
+  /** Base spin read accuracy floor (everyone can partially read spin). */
+  readAccuracyBase: number;
+  /** How much the spinRead attribute (0-100) adds to base accuracy. */
+  readAccuracySpinReadScale: number;
+  /** How much read difficulty reduces accuracy. */
+  readDifficultyPenalty: number;
+  /** Minimum read accuracy even in the worst case. */
+  minReadAccuracy: number;
+  /** Stddev scale for per-component Gaussian spin noise at max error. */
+  spinNoiseStddev: number;
+  /** Epsilon for zero-spin detection (avoids division by zero). */
+  spinMisreadEpsilon: number;
 }
 
 export const DEFAULT_PLAYER_ENGINE_CONFIG: PlayerEngineConfig = {
@@ -172,6 +188,15 @@ export const DEFAULT_PLAYER_ENGINE_CONFIG: PlayerEngineConfig = {
   targetJitterStddev: 3.0,
   serveWidthNoiseScale: 0.5,
   serveJitterStddev: 2.0,
+
+  // Spin read
+  readDifficultyScale: 1.2,
+  readAccuracyBase: 0.5,
+  readAccuracySpinReadScale: 0.5,
+  readDifficultyPenalty: 0.6,
+  minReadAccuracy: 0.05,
+  spinNoiseStddev: 0.4,
+  spinMisreadEpsilon: 0.001,
 };
 
 /** Merge a partial config with defaults. */

--- a/src/engine/player/spin-read.ts
+++ b/src/engine/player/spin-read.ts
@@ -1,0 +1,128 @@
+/**
+ * Spin read & deception system.
+ *
+ * Computes how well a receiver perceives the incoming ball's spin,
+ * based on the sender's deception ability/effort and the receiver's
+ * spinRead attribute.
+ *
+ * Pipeline:
+ *   readDifficulty  = f(sender deception attribute, shot deception effort)
+ *   readAccuracy    = f(receiver spinRead, readDifficulty)
+ *   perceivedSpin   = actualSpin + error(readAccuracy)
+ *
+ * The player engine receives ACTUAL spin from the physics engine.
+ * Spin perception is handled internally — different engine
+ * implementations can model perception differently (e.g. a robot
+ * engine with perfect spin reading).
+ */
+
+import type { Vec3 } from "../types/index.js";
+import type { Rng } from "../rng.js";
+import type { PlayerEngineConfig } from "./constants.js";
+import { clamp } from "../physics/vec-math.js";
+
+/**
+ * Compute how difficult the incoming spin is to read.
+ *
+ * Uses a multiplicative model: both the sender's deception attribute
+ * AND the effort on this shot must be high to create real difficulty.
+ * This matches the design rule: "high deception + low variation gains
+ * little" and "low deception + high variation is readable."
+ *
+ * @param senderDeception - Sender's deception attribute (0-100).
+ * @param deceptionEffort - Deception effort applied to this shot (0-1).
+ * @param config - Player engine config.
+ * @returns Read difficulty in [0, 1]. Higher = harder to read.
+ */
+export function computeReadDifficulty(
+  senderDeception: number,
+  deceptionEffort: number,
+  config: PlayerEngineConfig,
+): number {
+  return clamp(
+    (senderDeception / 100) * deceptionEffort * config.readDifficultyScale,
+    0,
+    1,
+  );
+}
+
+/**
+ * Compute how accurately the receiver reads the incoming spin.
+ *
+ * Everyone has a base level of spin reading ability (`readAccuracyBase`).
+ * The spinRead attribute adds on top. Read difficulty penalises accuracy.
+ *
+ * @param receiverSpinRead - Receiver's spinRead attribute (0-100).
+ * @param readDifficulty - Difficulty of reading the spin (0-1).
+ * @param config - Player engine config.
+ * @returns Read accuracy in [minReadAccuracy, 1]. Higher = better read.
+ */
+export function computeReadAccuracy(
+  receiverSpinRead: number,
+  readDifficulty: number,
+  config: PlayerEngineConfig,
+): number {
+  const base =
+    config.readAccuracyBase +
+    (receiverSpinRead / 100) * config.readAccuracySpinReadScale;
+  const penalized = base - readDifficulty * config.readDifficultyPenalty;
+  return clamp(penalized, config.minReadAccuracy, 1);
+}
+
+/**
+ * Compute the perceived spin from actual spin and read accuracy.
+ *
+ * Adds Gaussian noise to each component of the actual spin vector,
+ * scaled by the error factor (1 − readAccuracy) and the spin magnitude.
+ * Stronger spin is harder to precisely quantify, and lower accuracy
+ * produces larger errors — at very low accuracy the perceived direction
+ * can flip entirely (catastrophic misread).
+ *
+ * Returns both the perceived spin and a normalised misread magnitude
+ * (0 = perfect read, 1 = catastrophic misread).
+ *
+ * Zero-spin balls are always read correctly — there is nothing to
+ * misperceive when there is no spin.
+ *
+ * @param actualSpin - Actual ball spin vector (rev/s).
+ * @param readAccuracy - How accurately the spin is read (0-1).
+ * @param rng - Seedable RNG.
+ * @param config - Player engine config.
+ */
+export function computePerceivedSpin(
+  actualSpin: Vec3,
+  readAccuracy: number,
+  rng: Rng,
+  config: PlayerEngineConfig,
+): { perceivedSpin: Vec3; misread: number } {
+  const spinMag = Math.sqrt(
+    actualSpin.x * actualSpin.x +
+      actualSpin.y * actualSpin.y +
+      actualSpin.z * actualSpin.z,
+  );
+
+  // No spin → nothing to misread
+  if (spinMag < config.spinMisreadEpsilon) {
+    return { perceivedSpin: { ...actualSpin }, misread: 0 };
+  }
+
+  const errorFactor = 1 - readAccuracy;
+  const noiseScale = errorFactor * spinMag * config.spinNoiseStddev;
+
+  const perceivedSpin: Vec3 = {
+    x: actualSpin.x + rng.gaussian(0, noiseScale),
+    y: actualSpin.y + rng.gaussian(0, noiseScale),
+    z: actualSpin.z + rng.gaussian(0, noiseScale),
+  };
+
+  // Normalised misread: euclidean distance / spin magnitude, capped at 1
+  const dx = perceivedSpin.x - actualSpin.x;
+  const dy = perceivedSpin.y - actualSpin.y;
+  const dz = perceivedSpin.z - actualSpin.z;
+  const errorMag = Math.sqrt(dx * dx + dy * dy + dz * dz);
+
+  return {
+    perceivedSpin,
+    misread: clamp(errorMag / spinMag, 0, 1),
+  };
+}

--- a/src/engine/player/spin-read.ts
+++ b/src/engine/player/spin-read.ts
@@ -19,7 +19,7 @@
 import type { Vec3 } from "../types/index.js";
 import type { Rng } from "../rng.js";
 import type { PlayerEngineConfig } from "./constants.js";
-import { clamp } from "../physics/vec-math.js";
+import { clamp, v3mag, v3sub } from "../physics/vec-math.js";
 
 /**
  * Compute how difficult the incoming spin is to read.
@@ -95,11 +95,7 @@ export function computePerceivedSpin(
   rng: Rng,
   config: PlayerEngineConfig,
 ): { perceivedSpin: Vec3; misread: number } {
-  const spinMag = Math.sqrt(
-    actualSpin.x * actualSpin.x +
-      actualSpin.y * actualSpin.y +
-      actualSpin.z * actualSpin.z,
-  );
+  const spinMag = v3mag(actualSpin);
 
   // No spin → nothing to misread
   if (spinMag < config.spinMisreadEpsilon) {
@@ -116,10 +112,7 @@ export function computePerceivedSpin(
   };
 
   // Normalised misread: euclidean distance / spin magnitude, capped at 1
-  const dx = perceivedSpin.x - actualSpin.x;
-  const dy = perceivedSpin.y - actualSpin.y;
-  const dz = perceivedSpin.z - actualSpin.z;
-  const errorMag = Math.sqrt(dx * dx + dy * dy + dz * dz);
+  const errorMag = v3mag(v3sub(perceivedSpin, actualSpin));
 
   return {
     perceivedSpin,


### PR DESCRIPTION
## Summary
- Adds `spin-read.ts` module implementing the three-stage spin perception pipeline: read difficulty → read accuracy → perceived spin with Gaussian noise
- Uses a multiplicative model for read difficulty (both deception attribute AND effort must be high to create real difficulty), matching the design rule that "high deception + low variation gains little"
- Adds 7 new config values to `PlayerEngineConfig` for full tunability
- 19 new tests covering unit functions, boundary conditions, determinism, and full pipeline integration (attacker vs chopper scenarios)

## Test plan
- [x] All 59 player engine tests pass (40 existing + 19 new)
- [x] Build compiles cleanly
- [ ] Values will be tuned during physics tuning phase (Step 3 in proposal)