### PR TITLE
Add shot quality degradation: spin misread & stamina

### DIFF
--- a/src/engine/physics/__tests__/physics.test.ts
+++ b/src/engine/physics/__tests__/physics.test.ts
@@ -234,6 +234,43 @@ describe("execution quality", () => {
     const qLow = computeServeQuality(30, 80, 0.3, cfg);
     expect(qHigh).toBeGreaterThan(qLow);
   });
+
+  it("spin misread → reduced quality", () => {
+    const qClean = computeExecutionQuality(80, 0, 0.5, 0, cfg, 0, 1);
+    const qMisread = computeExecutionQuality(80, 0, 0.5, 0, cfg, 0.8, 1);
+    expect(qMisread).toBeLessThan(qClean);
+  });
+
+  it("low stamina → reduced quality", () => {
+    const qFresh = computeExecutionQuality(80, 0, 0.5, 0, cfg, 0, 1);
+    const qTired = computeExecutionQuality(80, 0, 0.5, 0, cfg, 0, 0.3);
+    expect(qTired).toBeLessThan(qFresh);
+  });
+
+  it("all five degradation factors together", () => {
+    const qPerfect = computeExecutionQuality(80, 0, 0.5, 0, cfg, 0, 1);
+    const qAll = computeExecutionQuality(80, 0.5, 0.1, 0.7, cfg, 0.6, 0.4);
+    expect(qAll).toBeLessThan(qPerfect * 0.5);
+    expect(qAll).toBeGreaterThanOrEqual(0);
+  });
+
+  it("default params produce same results as explicit neutral values", () => {
+    const qDefault = computeExecutionQuality(80, 0, 0.5, 0.3, cfg);
+    const qExplicit = computeExecutionQuality(80, 0, 0.5, 0.3, cfg, 0, 1);
+    expect(qDefault).toBeCloseTo(qExplicit);
+  });
+
+  it("serve quality with low stamina → reduced quality", () => {
+    const qFresh = computeServeQuality(80, 80, 0.3, cfg, 1);
+    const qTired = computeServeQuality(80, 80, 0.3, cfg, 0.3);
+    expect(qTired).toBeLessThan(qFresh);
+  });
+
+  it("serve quality default stamina matches explicit fresh", () => {
+    const qDefault = computeServeQuality(80, 80, 0.3, cfg);
+    const qExplicit = computeServeQuality(80, 80, 0.3, cfg, 1);
+    expect(qDefault).toBeCloseTo(qExplicit);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/engine/physics/constants.ts
+++ b/src/engine/physics/constants.ts
@@ -43,6 +43,8 @@ export interface PhysicsConfig {
   positionWeight: number;     // how much positional deficit hurts quality
   timePressureWeight: number; // how much time pressure hurts quality
   riskWeight: number;         // how much pushing ceilings hurts quality
+  spinMisreadWeight: number;  // how much spin misread hurts quality
+  staminaWeight: number;      // exponent for stamina degradation curve
 
   // --- Error model ---
   baseErrorStddev: number;    // base angular error in radians at quality=0
@@ -137,6 +139,8 @@ export const DEFAULT_PHYSICS_CONFIG: PhysicsConfig = {
   positionWeight: 0.6,
   timePressureWeight: 0.4,
   riskWeight: 0.5,
+  spinMisreadWeight: 0.5,
+  staminaWeight: 0.3,
 
   // Error model
   baseErrorStddev: 0.15,

--- a/src/engine/physics/index.ts
+++ b/src/engine/physics/index.ts
@@ -19,6 +19,7 @@ import type {
   ShotIntention,
   ServeIntention,
   BallFlight,
+  ShotDegradation,
 } from "../types/index.js";
 import type { Rng } from "../rng.js";
 import type { PhysicsConfig } from "./constants.js";
@@ -113,6 +114,7 @@ export class DefaultPhysicsEngine implements PhysicsEngine {
     capabilities: StrokeCapabilities,
     equipment: Equipment,
     arrival: ArrivalState,
+    degradation?: ShotDegradation,
   ): BallFlight {
     const { sideCaps, speed, spinMag, riskLevel } = this.resolvePhysicalValues(
       intention, capabilities, equipment,
@@ -125,6 +127,8 @@ export class DefaultPhysicsEngine implements PhysicsEngine {
       arrival.timeAvailable,
       riskLevel,
       this.config,
+      degradation?.spinMisread ?? 0,
+      degradation?.staminaFactor ?? 1,
     );
 
     // Compute intended velocity direction from contact point to target
@@ -180,6 +184,7 @@ export class DefaultPhysicsEngine implements PhysicsEngine {
     capabilities: StrokeCapabilities,
     equipment: Equipment,
     serviceSkill: number,
+    staminaFactor?: number,
   ): BallFlight {
     const { sideCaps, speed, spinMag, riskLevel } = this.resolvePhysicalValues(
       intention, capabilities, equipment,
@@ -191,6 +196,7 @@ export class DefaultPhysicsEngine implements PhysicsEngine {
       sideCaps.consistency,
       riskLevel,
       this.config,
+      staminaFactor ?? 1,
     );
 
     // Serve starts behind the server's end line

--- a/src/engine/player/constants.ts
+++ b/src/engine/player/constants.ts
@@ -122,6 +122,16 @@ export interface PlayerEngineConfig {
   spinNoiseStddev: number;
   /** Epsilon for zero-spin detection (avoids division by zero). */
   spinMisreadEpsilon: number;
+
+  // --- Stamina ---
+  /** Base fatigue gained per shot (before stamina attribute scaling). */
+  staminaDrainBase: number;
+  /** Extra fatigue per unit of positional deficit (stretched play costs more). */
+  staminaDrainDeficitScale: number;
+  /** Fatigue recovered between games (fraction of current fatigue). */
+  staminaGameRecovery: number;
+  /** Fatigue recovered when taking a timeout (fraction of current fatigue). */
+  staminaTimeoutRecovery: number;
 }
 
 export const DEFAULT_PLAYER_ENGINE_CONFIG: PlayerEngineConfig = {
@@ -197,6 +207,12 @@ export const DEFAULT_PLAYER_ENGINE_CONFIG: PlayerEngineConfig = {
   minReadAccuracy: 0.05,
   spinNoiseStddev: 0.4,
   spinMisreadEpsilon: 0.001,
+
+  // Stamina
+  staminaDrainBase: 0.002,
+  staminaDrainDeficitScale: 0.005,
+  staminaGameRecovery: 0.15,
+  staminaTimeoutRecovery: 0.1,
 };
 
 /** Merge a partial config with defaults. */

--- a/src/engine/types/index.ts
+++ b/src/engine/types/index.ts
@@ -43,6 +43,7 @@ export type {
   ShotIntention,
   ServeIntention,
   BallFlight,
+  ShotDegradation,
   ServeRuling,
   ShotRuling,
   MatchState,


### PR DESCRIPTION
## Summary
- Complete the execution quality pipeline by adding the final 2 of 5 degradation factors: **spin misread** and **stamina**
- Integrate the existing (but orphaned) spin read system into DefaultPlayerEngine — spin misread now computed on each `decideShot` call
- Add stamina fatigue tracking to DefaultPlayerEngine with per-shot drain (scaled by positional deficit + stamina attribute) and between-game/timeout recovery
- Extend `computeExecutionQuality` with `spinMisread` and `staminaFactor` params (defaults preserve backward compatibility)
- Add `ShotDegradation` type and update `PhysicsEngine`/`PlayerEngine` interfaces for match engine integration

## Test plan
- [x] 7 new physics tests: spin misread degrades quality, stamina degrades quality, all 5 factors combined, serve stamina, default params backward compat
- [x] 9 new player engine tests: initial state, misread computation, fatigue accumulation, deficit scaling, stamina attribute effect, game/timeout recovery, bounds safety
- [x] All 116 tests pass (was 100)
- [x] Build compiles cleanly